### PR TITLE
Splmemfix

### DIFF
--- a/8-BinaryTree/main.c
+++ b/8-BinaryTree/main.c
@@ -8,6 +8,9 @@ The problem is that t2 will be changed
 
 Using codebase from https://www.geeksforgeeks.org/introduction-to-splay-tree-data-structure/
 Should learn it by heart
+
+This approuch leads to memleak if tree is allocated in heap
+This won't lead to leaks if tree is being allocated onto stack
 */
 
 
@@ -106,7 +109,7 @@ int main(void)
     Tree t2_2 = {2, 0, &t2_3};
     Tree t2 = {1, 0, &t2_2};
 
-    // printf("%d", is_subset(1, &t1, &t2));
-    print_tree(&t2);
+    printf("%d", is_subset(1, &t1, &t2));
+    // print_tree(&t2);
     return 0;
 }

--- a/8-BinaryTree/main.c
+++ b/8-BinaryTree/main.c
@@ -25,7 +25,7 @@ struct tree
     int x;
     Tree *left, *right;
 };
-
+/*
 Tree* rightrot(Tree *t)
 {
     Tree *tt = t->left;
@@ -41,39 +41,77 @@ Tree* leftrot(Tree *t)
     tt->left = t;
     return tt;
 }
+*/
 
-Tree* splay(Tree *root, int key)
+void rightrot(Tree *t)
 {
-    if (!root || root->x == key) return root;
+    Tree *tt = t->left;
+    t->left = tt->right;
+    tt->right = tt;
+
+    // swaping
+    Tree *r = calloc(1, sizeof(Tree));
+    memcpy(r, t, sizeof(Tree));
+    memcpy(t, tt, sizeof(Tree));
+    memcpy(tt, r, sizeof(Tree));
+    free(r);
+}
+
+void leftrot(Tree *t)
+{
+    Tree *tt = t->right;
+    t->right = tt->left;
+    tt->left = tt;
+
+    Tree *r = calloc(1, sizeof(Tree));
+    memcpy(r, t, sizeof(Tree));
+    memcpy(t, tt, sizeof(Tree));
+    memcpy(tt, r, sizeof(Tree));
+    free(r);
+}
+
+//Tree* splay(Tree *root, int key)
+void splay(Tree *root, int key)
+{
+    if (!root || root->x == key) return; //root;
     if (key < root->x)
     {
-        if (!root->left) return root;
+        if (!root->left) return;// root;
         if (key < root->left->x)
         {
-            root->left->left = splay(root->left->left, key);
-            root = rightrot(root);
+            // root->left->left = splay(root->left->left, key);
+            splay(root->left->left, key);
+            // root = rightrot(root);
+            rightrot(root);
         }
         else if (root->left->x < key)
         {
-            root->left->right = splay(root->left->right, key);
-            if (root->left->right) root->left = leftrot(root->left);
+            // root->left->right = splay(root->left->right, key);
+            splay(root->left->right, key);
+            if (root->left->right) leftrot(root->left);// root->left = leftrot(root->left);
         }
-        return root->left ? rightrot(root) : root;
+        root->left ? rightrot(root) : root;
+        return;
     }
     else
     {
-        if (!root->right) return root;
+        if (!root->right) return;// root;
         if (root->right->x < key)
         {
-            root->right->right = splay(root->right->right, key);
-            root = leftrot(root);
+            // root->right->right = splay(root->right->right, key);
+            splay(root->right->right, key);
+            // root = leftrot(root);
+            leftrot(root);
         }
         else if (key < root->right->x)
         {
-            root->right->left = splay(root->right->left, key);
-            if (root->right->left) root->right = rightrot(root->right);
+            //root->right->left = splay(root->right->left, key);
+            splay(root->right->left, key);
+            // if (root->right->left) root->right = rightrot(root->right);
+            rightrot(root->right);
         }
-        return root->right ? leftrot(root) : root;
+        root->right ? leftrot(root) : root;
+        return;
     }
 }
 
@@ -82,7 +120,8 @@ int is_subset(int size, Tree *t1, Tree *t2)
     if (!t1) return 1;
     if (!t2) return 0;
 
-    t2 = splay(t2, t1->x);
+    // t2 = splay(t2, t1->x);
+    splay(t2, t1->x);
     if (t2->x != t1->x) return 0;
 
     return is_subset(1, t1->left, t2->left) && is_subset(1, t1->right, t2->right);
@@ -98,8 +137,9 @@ void print_tree(Tree *t)
 
 int main(void)
 {
+    Tree t1_5 = {6, 0, 0};
     Tree t1_4 = {3, 0, 0};
-    Tree t1_3 = {5, &t1_4, 0};
+    Tree t1_3 = {5, &t1_4, &t1_5};
     Tree t1_2 = {2, 0, &t1_3};
     Tree t1 = {1, 0, &t1_2};
 


### PR DESCRIPTION
We couldn't use regular rotation we used to rotate tree to remain splay tree balanced. In `is_subset` function we don't have ability to throw new pointer outside of this function. So We had to reinvent rotation function.

Now rotation moves data between data segments. This way real root remains on the same address as last root was. It's good trick to remember for exam.