### PR TITLE
Fritree fixed branch-as-tree validation

### DIFF
--- a/FriTree/main.c
+++ b/FriTree/main.c
@@ -52,7 +52,7 @@ int checkDown(Node* n, Node* last)
         deg4cnt += (*i)->deg == 4;
         if ((*i)->deg == 4) gon = *i;
 
-        if (!isBranch(*i, n)) return 0;
+        if ((*i)->deg != 4 && !isBranch(*i, n)) return 0;
     }
     if (deg4cnt > 1) return 0;
 


### PR DESCRIPTION
There was a problem, 4-degree top has been passed to tree validation.